### PR TITLE
Add TypeScript example for pairing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@
 
 out
 build
+
+# Node
+node_modules
+ts-x3d/dist

--- a/ts-x3d/README.md
+++ b/ts-x3d/README.md
@@ -1,0 +1,22 @@
+# TypeScript X3D Example
+
+This folder contains a minimal TypeScript example demonstrating how to send
+an X3D pairing message via a serial connected radio dongle.
+
+It uses the `serialport` package to access the USB device. The example assumes
+the dongle is available at `/dev/ttyUSB0` and runs at 115200 baud.
+
+To build the project:
+
+```sh
+npm install  # install dependencies (requires internet access)
+npx tsc      # compile into `dist/`
+```
+
+Then run the script with:
+
+```sh
+node dist/index.js
+```
+
+This simply sends a basic pairing frame on the serial port.

--- a/ts-x3d/package.json
+++ b/ts-x3d/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "ts-x3d",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/ts-x3d/src/index.ts
+++ b/ts-x3d/src/index.ts
@@ -1,0 +1,16 @@
+import { SerialPort } from 'serialport';
+import { buildPairingMessage } from './x3d';
+
+async function main() {
+  const port = new SerialPort({ path: '/dev/ttyUSB0', baudRate: 115200 });
+
+  const buffer = Buffer.alloc(64);
+  const slot = 0; // example new slot
+  const pin = 0x0000; // unknown pairing pin
+  const pairingMsg = buildPairingMessage(slot, pin);
+
+  port.write(pairingMsg);
+  console.log('Pairing message sent');
+}
+
+main().catch(err => console.error(err));

--- a/ts-x3d/src/x3d.ts
+++ b/ts-x3d/src/x3d.ts
@@ -1,0 +1,34 @@
+// Minimal helper to build a pairing request frame
+
+/**
+ * Build a X3D pairing message payload.
+ * @param targetSlot The slot number (0-15) for the new device
+ * @param pin Optional pairing pin (0 if unknown)
+ */
+export function buildPairingMessage(targetSlot: number, pin: number): Buffer {
+  const buf = Buffer.alloc(16);
+  let i = 0;
+
+  // message header
+  buf[i++] = 0; // length, will be filled later
+  buf[i++] = 0; // addr placeholder
+  buf[i++] = 0; // msg id low
+  buf[i++] = 0; // msg type pairing
+  buf[i++] = 0; // header len
+  buf[i++] = 0; // device id
+  buf[i++] = 0;
+  buf[i++] = 0;
+  buf[i++] = 4; // network number
+  buf[i++] = 0; // status
+  buf[i++] = 0; // retry
+
+  // payload pairing data
+  buf[i++] = 0x00; // cnt + device nibble
+  buf.writeUInt16LE(0xff1f, i); i += 2;
+  buf.writeUInt16LE(targetSlot, i); i += 2;
+  buf.writeUInt16LE(pin, i); i += 2;
+  buf.writeUInt16LE(0xe0, i); i += 2;
+
+  buf[0] = i - 1; // length without preamble
+  return buf.slice(0, i);
+}

--- a/ts-x3d/tsconfig.json
+++ b/ts-x3d/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add a simple TypeScript example for X3D pairing
- ignore Node build artifacts

## Testing
- `npx tsc -p ts-x3d` *(fails: Cannot find module 'serialport' or type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685da31287548322a5d6693ce3d08c2f